### PR TITLE
Renamed Flipper to FeatureFlipper to prevent ambiguous references between the namespace and the class.

### DIFF
--- a/Flipper.Tests/FeatureTests.cs
+++ b/Flipper.Tests/FeatureTests.cs
@@ -13,133 +13,133 @@ namespace Flipper.Tests
        [Test]
        public void Can_Activate_Feature()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivateFeature(feature);
+           FeatureFlipper.ActivateFeature(feature);
 
-           Assert.IsTrue(flipper.IsActive(feature));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature));
        }
 
        [Test]
        public void Can_Set_Active_Feature_To_Deactive()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivateFeature(feature);
+           FeatureFlipper.ActivateFeature(feature);
 
-           Assert.IsTrue(flipper.IsActive(feature));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature));
 
-           flipper.DeactiveFeature(feature);
+           FeatureFlipper.DeactiveFeature(feature);
 
-           Assert.IsFalse(flipper.IsActive(feature));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature));
        }
 
        [Test]
        public void Can_Define_A_Group()
        {
-           flipper.DefineGroup("test", new List<string>() { "1" });
+           FeatureFlipper.DefineGroup("test", new List<string>() { "1" });
 
-           Assert.IsTrue(flipper.GetGroup("test").Contains("1"));
+           Assert.IsTrue(FeatureFlipper.GetGroup("test").Contains("1"));
        }
 
 
        [Test]
        public void Can_Activate_A_Group()
        {
-           flipper.DefineGroup("test", new List<string>() { "1" });
+           FeatureFlipper.DefineGroup("test", new List<string>() { "1" });
 
-           var feature = flipper.Get("test");
+           var feature = FeatureFlipper.Get("test");
 
-           flipper.ActivateGroup(feature, "test");
+           FeatureFlipper.ActivateGroup(feature, "test");
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
        }
 
        [Test]
        public void Can_Deactivate_An_Activte_Group()
        {
-           flipper.DefineGroup("test", new List<string>() { "1" });
-           var feature = flipper.Get("test");
+           FeatureFlipper.DefineGroup("test", new List<string>() { "1" });
+           var feature = FeatureFlipper.Get("test");
 
-           flipper.ActivateGroup(feature, "test");
+           FeatureFlipper.ActivateGroup(feature, "test");
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
 
-           flipper.DeactivateGroup(feature, "test");
+           FeatureFlipper.DeactivateGroup(feature, "test");
 
-           Assert.IsFalse(flipper.IsActive(feature, "1"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "1"));
        }
 
        [Test]
        public void Can_Activate_New_User_In_Feature()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivateUser(feature, "1");
+           FeatureFlipper.ActivateUser(feature, "1");
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
 
        }
 
        [Test]
        public void Can_Deactivate_A_User_In_A_Feature()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivateUser(feature, "1");
+           FeatureFlipper.ActivateUser(feature, "1");
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
 
-           flipper.DeactivateUser(feature, "1");
+           FeatureFlipper.DeactivateUser(feature, "1");
 
-           Assert.IsFalse(flipper.IsActive(feature, "1"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "1"));
        }
 
        [Test]
        public void Can_Activate_A_Percentage()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
            
-           flipper.ActivatePercentage(feature, 1);
+           FeatureFlipper.ActivatePercentage(feature, 1);
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
-           Assert.IsFalse(flipper.IsActive(feature, "2"));
-           Assert.IsFalse(flipper.IsActive(feature, "21"));
-           Assert.IsFalse(flipper.IsActive(feature, "31"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "2"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "21"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "31"));
 
-           flipper.ActivatePercentage(feature, 21);
+           FeatureFlipper.ActivatePercentage(feature, 21);
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
-           Assert.IsTrue(flipper.IsActive(feature, "102"));
-           Assert.IsTrue(flipper.IsActive(feature, "1021"));
-           Assert.IsFalse(flipper.IsActive(feature, "31"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "102"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1021"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "31"));
 
        }
 
        [Test]
        public void Can_Deactivate_A_Percentage()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivatePercentage(feature, 1);
+           FeatureFlipper.ActivatePercentage(feature, 1);
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
 
-           flipper.DeactivatePercentage(feature);
+           FeatureFlipper.DeactivatePercentage(feature);
 
-           Assert.IsFalse(flipper.IsActive(feature, "1"));
+           Assert.IsFalse(FeatureFlipper.IsActive(feature, "1"));
        }
 
        [Test]
        public void Feature_Is_Always_Active_If_Percentage_Set_To_100()
        {
-           var feature = flipper.Get("Test");
+           var feature = FeatureFlipper.Get("Test");
 
-           flipper.ActivateFeature(feature);
+           FeatureFlipper.ActivateFeature(feature);
 
-           Assert.IsTrue(flipper.IsActive(feature, "1"));
-           Assert.IsTrue(flipper.IsActive(feature));
-           Assert.IsTrue(flipper.IsActive(feature, "12341"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "1"));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature));
+           Assert.IsTrue(FeatureFlipper.IsActive(feature, "12341"));
            
        }
    }

--- a/Flipper.Tests/TestBase.cs
+++ b/Flipper.Tests/TestBase.cs
@@ -11,20 +11,20 @@ namespace Flipper.Tests
     [TestFixture]
     public class TestBase
     {
-        protected Flipper flipper;
+        protected FeatureFlipper FeatureFlipper;
         private IRedisClientsManager manager;
 
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
             manager = new BasicRedisClientManager("localhost:6379");
-            flipper = new Flipper(manager);           
+            FeatureFlipper = new FeatureFlipper(manager);           
         }
 
         [TestFixtureTearDown]
         public void TestFixtureTearDown()
         {
-            flipper = null;
+            FeatureFlipper = null;
         }
 
         [SetUp]

--- a/Flipper/Flipper.cs
+++ b/Flipper/Flipper.cs
@@ -14,10 +14,10 @@ namespace Flipper
         public List<string> Groups { get; set; }
         public int Percentage { get; set; }
 
-        public Feature(Flipper flipper, string Name)
+        public Feature(FeatureFlipper FeatureFlipper, string Name)
         {
             this.Name = Name;
-            flipper.LoadFeature(this);
+            FeatureFlipper.LoadFeature(this);
         }
 
         public void AddUser(string user)
@@ -53,7 +53,7 @@ namespace Flipper
             Percentage = 0;
         }
 
-        public bool IsActive(Flipper flipper, string user)
+        public bool IsActive(FeatureFlipper FeatureFlipper, string user)
         {
             if (user == "")
             {
@@ -61,16 +61,16 @@ namespace Flipper
             }
             else
             {
-                return int.Parse(user) % 100 <= Percentage || Users.Contains(user) || flipper.UserInGroup(user, Groups);
+                return int.Parse(user) % 100 <= Percentage || Users.Contains(user) || FeatureFlipper.UserInGroup(user, Groups);
             }
         }
     }
 
-    public class Flipper
+    public class FeatureFlipper
     {
         private IRedisClientsManager manager;
 
-        public Flipper(IRedisClientsManager Manager)
+        public FeatureFlipper(IRedisClientsManager Manager)
         {
             manager = Manager;
         }


### PR DESCRIPTION
Having class with the same name as the namespace forces external consumers to always reference the class as Flipper.Flipper(). Using directives to help. This only shows up when you attempt to consume the class from a namespace that is not part of the Flipper namespace. It works in the test classes because they are in a descendant namespace of Flipper. 
